### PR TITLE
close client at end instead of calling flush()

### DIFF
--- a/test.py
+++ b/test.py
@@ -31,4 +31,4 @@ if __name__ == "__main__":
   else:
     print "Not showing your feature"
 
-  ldclient.get().flush()
+  ldclient.get().close() # close the client before exiting the program - ensures that all events are delivered


### PR DESCRIPTION
Flush() used to be synchronous but now it's not, so close() is the right way to ensure that all events are sent before exiting.