### PR TITLE
Adding example of logging and custom context

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,6 +69,14 @@ if __name__ == "__main__":
     context = \
         Context.builder('example-user-key').kind('user').name('Sandy').build()
 
+    # If you want to try a custom context, uncomment the next six lines
+    #org_context = Context.builder("org-acme-123").kind("organization") \
+    #  .set("name", "Acme Corp") \
+    #  .set("industry", "retail") \
+    #  .set("region", "EMEA") \
+    #  .set("subscriptionTier", "enterprise") \
+    #  .build()
+    
     flag_value = ldclient.get().variation(feature_flag_key, context, False)
     show_evaluation_result(feature_flag_key, flag_value)
 

--- a/main.py
+++ b/main.py
@@ -1,10 +1,14 @@
 import os
 import ldclient
+## uncomment the next line to enable debug logging
+## import sys
 from ldclient import Context
 from ldclient.config import Config
 from threading import Event
 from halo import Halo
-
+## uncomment the next two lines to enable debug logging
+## logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+## logging.getLogger("launchdarkly_sdk").setLevel(logging.DEBUG)
 
 # Set sdk_key to your LaunchDarkly SDK key.
 sdk_key = os.getenv('LAUNCHDARKLY_SDK_KEY')


### PR DESCRIPTION
In an engagement it was seen as useful to have logging and custom context examples quickly available in the demo code.