### PR TITLE
chore: update Python requirement to 3.10 for latest SDK compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Install poetry
         uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ We've built a simple console application that demonstrates how LaunchDarkly's SD
 
 Below, you'll find the build procedure. For more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Python reference guide](https://docs.launchdarkly.com/sdk/server-side/python).
 
-This demo requires Python 3.9 or higher.
+This demo requires Python 3.10 or higher.
 
 ## Build instructions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 launchdarkly-server-sdk = ">=9.0.0"
 halo = ">=0.0.3"
 


### PR DESCRIPTION
## Summary

Bumps the minimum Python version from 3.9 to 3.10. The latest `launchdarkly-server-sdk` (9.15.0+) requires Python ≥3.10, so this change is needed to ensure the example resolves to the latest SDK version when users run `poetry install`.

Updates `pyproject.toml` and `README.md` to reflect the new requirement.

Link to Devin session: https://app.devin.ai/sessions/d0545f9be7594100bb281ceb0584d2ae
Requested by: @kinyoklion