### PR TITLE
chore: update launchdarkly-server-sdk to 9.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-launchdarkly-server-sdk = ">=9.0.0"
+launchdarkly-server-sdk = ">=9.16.0"
 halo = ">=0.0.3"
 
 


### PR DESCRIPTION
## Summary

Update `launchdarkly-server-sdk` minimum version constraint from `>=9.0.0` to `>=9.16.0`.

No deprecated APIs found in the example code — the app uses the modern `Context` API and current SDK patterns.

Tested successfully: SDK initializes and evaluates flags as expected.

Link to Devin session: https://app.devin.ai/sessions/e58d80c462594beca14888a34bf57d15
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency floor change with no code edits; low risk unless 9.16+ introduces breaking behavior for this app’s usage.
> 
> **Overview**
> **Dependency bump only:** the Poetry constraint for `launchdarkly-server-sdk` in `pyproject.toml` changes from `>=9.0.0` to `>=9.16.0`, so installs resolve to SDK 9.16+.
> 
> No application source changes in this diff; the PR description notes the sample already uses current patterns (e.g. `Context`) and was smoke-tested for init and flag evaluation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94663d0c0aeaf59ca362461d7a89adf5e37f5774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->